### PR TITLE
explained what deploy script does in deploy instructions, fixes #147

### DIFF
--- a/handlers/deployinstructions.go
+++ b/handlers/deployinstructions.go
@@ -39,11 +39,17 @@ func (h DeployInstructionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 
 	// {{{1 Return instructions
 	h.RespondJSON(w, http.StatusOK, map[string]string{
-		"instructions": fmt.Sprintf("To deploy %s run the following command:  \n"+
+		"instructions": fmt.Sprintf("To deploy the %s application run the following command **in bash**:  \n"+
 			"```\n"+
 			". <(curl -L %s/apps/id/%s/deploy.sh)\n"+
-			"```",
+			"```\n"+
+			"  \n"+
+			"This command will complete the following actions:\n"+
+			"- Present values for any `ConfigMap` and / or `Secret` resources and give you a chance to customize them\n"+
+			"- Deploy app's resource manifests, with any custom values, to your cluster using `kubectl`\n"+
+			"  \n"+
+			"You can see the [raw resource manifests for the %s app here](%s/apps/id/%s/deployment.json)",
 			app.Name,
-			h.Cfg.ExternalURL.String(), app.AppID),
+			h.Cfg.ExternalURL.String(), app.AppID, app.Name, h.Cfg.ExternalURL.String(), app.AppID),
 	})
 }


### PR DESCRIPTION
Example output after changes:

> To deploy the Serverless Example NodeJS application run the following command **in bash**:  
> ```
> . <(curl -L http://localhost:5000/apps/id/serverless-example-nodejs/deploy.sh)
> ```
>   
> This command will complete the following actions:
> - Present values for any `ConfigMap` and / or `Secret` resources and give you a chance to customize them
> - Deploy app's resource manifests, with any custom values, to your cluster using `kubectl`
>   
> You can see the [raw resource manifests for the Serverless Example NodeJS app here](http://localhost:5000/apps/id/serverless-example-nodejs/deployment.json)