### PR TITLE
added schemes to urls in content returned by deploy instructions endpoint, fixes #150

### DIFF
--- a/handlers/deployinstructions.go
+++ b/handlers/deployinstructions.go
@@ -41,14 +41,14 @@ func (h DeployInstructionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 	h.RespondJSON(w, http.StatusOK, map[string]string{
 		"instructions": fmt.Sprintf("To deploy the %s application run the following command **in bash**:  \n"+
 			"```\n"+
-			". <(curl -L %s/apps/id/%s/deploy.sh)\n"+
+			". <(curl -L https://%s/apps/id/%s/deploy.sh)\n"+
 			"```\n"+
 			"  \n"+
 			"This command will complete the following actions:\n"+
 			"- Present values for any `ConfigMap` and / or `Secret` resources and give you a chance to customize them\n"+
 			"- Deploy app's resource manifests, with any custom values, to your cluster using `kubectl`\n"+
 			"  \n"+
-			"You can see the [raw resource manifests for the %s app here](%s/apps/id/%s/deployment.json)",
+			"You can see the [raw resource manifests for the %s app here](https://%s/apps/id/%s/deployment.json)",
 			app.Name,
 			h.Cfg.ExternalURL.String(), app.AppID, app.Name, h.Cfg.ExternalURL.String(), app.AppID),
 	})


### PR DESCRIPTION
Response which deploy instructions returns now:

> To deploy the Serverless Example NodeJS application run the following command **in bash**:  
> ```
> . <(curl -L https://http://localhost:5000/apps/id/serverless-example-nodejs/deploy.sh)
> ```
>  
> This command will complete the following actions:
> - Present values for any `ConfigMap` and / or `Secret` resources and give you a chance to customize them
> - Deploy app's resource manifests, with any custom values, to your cluster using `kubectl`
>   
> You can see the [raw resource manifests for the Serverless Example NodeJS app here](https://http://localhost:5000/apps/id/serverless-example-nodejs/deployment.json)

Notice the `https` in the `curl` command and how the ~"raw resource manifests" link now points to api.kscout.io with HTTPS.