### PR TITLE
fixed reading Config.BotAPIURL value from env var

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -23,7 +23,7 @@ type Config struct {
 
 	// BotAPIURL is the URL of the bot API.
 	// Must include a schema.
-	BotAPIURL url.URL `default:"http://localhost:8000" split_words:"true" required:"true"`
+	BotAPIURL url.URL `default:"http://localhost:8000" envconfig:"bot_api_url" required:"true"`
 
 	// APIAddr is the API server's bind address
 	APIAddr string `default:":5000" split_words:"true" required:"true"`


### PR DESCRIPTION
The API was supposed to get the `config.Config.BotAPIURL` field value from the `APP_BOT_API_URL` environment variable. However due to: 1) 2 capital words "API" and "URL" next to each other and 2) the logic used to retrieve config values from env vars:  the app was looking for config in the `APP_BOT_APIURL` env var.

This PR manually overrides the name of the env var which the `BotAPIURL` field looks in to be the correct one.